### PR TITLE
Mention PHP's various array index types

### DIFF
--- a/php2rpg.md
+++ b/php2rpg.md
@@ -1,8 +1,9 @@
 # php2rpg
 Guide showing you PHP and RPG differences
 
-* RPG is strongly typed. 
-* RPG indexes start at 1, where PHP starts at 0.
+* RPG is strongly typed.
+* RPG indexes start at 1, where PHP's numeric indexes start at 0. 
+* RPG's array indexes are always numeric; PHP's array indexes can be numeric or string.
 * Variables in PHP start with a Dollar sign. ($)
 
 ***


### PR DESCRIPTION
The implication before was that PHP's indexes were always numeric as RPG's are. I added language to make clear that strings are also permitted as array indexes.